### PR TITLE
Add support for subscriptions that use `DeserializeSeed`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["network-programming", "science::robotics"]
 
 [dependencies]
 
-rustdds = {  path = "../RustDDS"  } # dev setting
-# rustdds = {   git = "https://github.com/jhelovuo/RustDDS.git" }
+# rustdds = {  path = "../RustDDS"  } # dev setting
+rustdds = {   git = "https://github.com/jhelovuo/RustDDS.git" }
 # rustdds = {  version = "0.8.3"  } # release setting
 
 mio = "^0.6.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["network-programming", "science::robotics"]
 [dependencies]
 
 # rustdds = {  path = "../RustDDS"  } # dev setting
-rustdds = {   git = "https://github.com/jhelovuo/RustDDS.git" }
+rustdds = {   git = "https://github.com/dora-rs/RustDDS.git", branch = "deserialize-seed" }
 # rustdds = {  version = "0.8.3"  } # release setting
 
 mio = "^0.6.23"

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,7 +6,7 @@ use std::{
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 use mio::Evented;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 use rustdds::{
   dds::CreateResult,
   no_key::{DeserializerAdapter, SerializerAdapter},
@@ -84,7 +84,7 @@ impl Context {
     qos: Option<QosPolicies>,
   ) -> dds::CreateResult<Subscription<M>>
   where
-    M: 'static + DeserializeOwned,
+    M: 'static,
   {
     let datareader = self
       .get_ros_default_subscriber()

--- a/src/node.rs
+++ b/src/node.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 use rustdds::{
   dds::{CreateError, CreateResult},
   *,
@@ -257,7 +257,7 @@ impl Node {
   /// * `topic` - Reference to topic created with `create_ros_topic`.
   /// * `qos` - Should take [QOS](../dds/qos/struct.QosPolicies.html) and use if
   ///   it's compatible with topics QOS. `None` indicates the use of Topics QOS.
-  pub fn create_subscription<D: DeserializeOwned + 'static>(
+  pub fn create_subscription<D: 'static>(
     &mut self,
     topic: &Topic,
     qos: Option<QosPolicies>,

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -131,12 +131,12 @@ impl<M: 'static> Subscription<M> {
   }
 
   // Returns an async Stream of messages with MessageInfo metadata
-  pub fn async_stream_seed<S>(
+  pub fn async_stream_seed<'de, S>(
     &self,
     seed: S,
   ) -> impl Stream<Item = ReadResult<(M, MessageInfo)>> + FusedStream + '_
   where
-    S: for<'a> DeserializeSeed<'a, Value = M> + Clone + 'static,
+    S: DeserializeSeed<'de, Value = M> + Clone + 'static,
   {
     self
       .datareader

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -130,6 +130,20 @@ impl<M: 'static> Subscription<M> {
       .map(|result| result.map(dcc_to_value_and_messageinfo))
   }
 
+  // Returns an async Stream of messages with MessageInfo metadata
+  pub fn async_stream_seed<S>(
+    &self,
+    seed: S,
+  ) -> impl Stream<Item = ReadResult<(M, MessageInfo)>> + FusedStream + '_
+  where
+    S: for<'a> DeserializeSeed<'a, Value = M> + Clone + 'static,
+  {
+    self
+      .datareader
+      .as_async_stream_seed(seed)
+      .map(|result| result.map(dcc_to_value_and_messageinfo))
+  }
+
   pub fn guid(&self) -> rustdds::GUID {
     self.datareader.guid()
   }

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -91,6 +91,15 @@ impl<M: 'static + DeserializeOwned> Subscription<M> {
     Ok(ds.map(dcc_to_value_and_messageinfo))
   }
 
+  pub fn take_seed<'de, S>(&self, seed: S) -> dds::ReadResult<Option<(M, MessageInfo)>>
+  where
+    S: DeserializeSeed<'de, Value = M>,
+  {
+    self.datareader.drain_read_notifications();
+    let ds: Option<no_key::DeserializedCacheChange<M>> = self.datareader.try_take_one_seed(seed)?;
+    Ok(ds.map(dcc_to_value_and_messageinfo))
+  }
+
   pub async fn async_take(&self) -> ReadResult<(M, MessageInfo)> {
     let async_stream = self.datareader.as_async_stream();
     pin_mut!(async_stream);

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -10,7 +10,10 @@ use rustdds::{
   rpc::SampleIdentity,
   *,
 };
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{
+  de::{DeserializeOwned, DeserializeSeed},
+  Serialize,
+};
 
 /// A ROS2 Publisher
 ///
@@ -72,7 +75,7 @@ impl<M: Serialize> Publisher<M> {
 ///
 /// Corresponds to a (simplified) [`DataReader`](rustdds::no_key::DataReader) in
 /// DDS
-pub struct Subscription<M: DeserializeOwned> {
+pub struct Subscription<M> {
   datareader: no_key::SimpleDataReaderCdr<M>,
 }
 


### PR DESCRIPTION
Some types need additional context for deserialization, which makes it impossible to implement `DeserializeOwned`. Instead, deserialization happens through the [`DeserializeSeed`](https://docs.rs/serde/1.0.174/serde/de/trait.DeserializeSeed.html) trait.

This PR adds support for creating subscriptions that use `DeserializeSeed`. The two main API changes are:

- Don't require the `DeserializeOwned` bound to create subscriptions. Instead, require them only for the methods that absolutely need it (such as `take`).
- Add a new `take_seed` method that deserializes using `DeserializeSeed`.

These changes depend on two other PRs. We might want to upstream it once they are merged:

- https://github.com/jhelovuo/RustDDS/pull/291
- https://github.com/dora-rs/RustDDS/pull/2